### PR TITLE
Disable saturated regeneration

### DIFF
--- a/src/main/java/supercoder79/survivalgames/game/SurvivalGamesActive.java
+++ b/src/main/java/supercoder79/survivalgames/game/SurvivalGamesActive.java
@@ -88,6 +88,7 @@ public final class SurvivalGamesActive {
             game.setRule(GameRuleType.BLOCK_DROPS, ActionResult.PASS);
             game.setRule(GameRuleType.FALL_DAMAGE, ActionResult.PASS);
             game.setRule(GameRuleType.HUNGER, ActionResult.FAIL);
+            game.setRule(GameRuleType.SATURATED_REGENERATION, ActionResult.FAIL);
             game.setRule(GameRuleType.UNSTABLE_TNT, ActionResult.PASS);
             game.setRule(GameRuleType.THROW_ITEMS, ActionResult.SUCCESS);
             game.setRule(SurvivalGames.DISABLE_SPAWNERS, ActionResult.SUCCESS);


### PR DESCRIPTION
This pull request disables the saturated regeneration rule type. Since hunger is disabled in this game, saturated regeneration will always occur, and players will regenerate health too quickly for combat to quickly end.

Saturated regeneration is already disabled in Cake Wars, Cabin Fever, and Farmy Feud; there is also [a pull request](https://github.com/NucleoidMC/bed-wars/pull/68) to disable saturated regeneration in Bed Wars.