### PR TITLE
Fix the game closing delay not working

### DIFF
--- a/src/main/java/supercoder79/survivalgames/game/SurvivalGamesActive.java
+++ b/src/main/java/supercoder79/survivalgames/game/SurvivalGamesActive.java
@@ -117,7 +117,7 @@ public final class SurvivalGamesActive {
         world.getWorldBorder().setCenter(0, 0);
         world.getWorldBorder().setSize(config.borderConfig.startSize);
         world.getWorldBorder().setDamagePerBlock(0.5);
-        startTime = world.getTime();
+        startTime = space.getTime();
 
         int index = 0;
 
@@ -162,14 +162,16 @@ public final class SurvivalGamesActive {
     }
 
     private void tick() {
+        long time = this.space.getTime();
+
         if (!this.borderShrinkStarted) {
             long totalSafeTime = config.borderConfig.safeSecs * 20L;
-            this.bar.tickSafe(totalSafeTime - (world.getTime() - startTime), totalSafeTime);
+            this.bar.tickSafe(totalSafeTime - (time - startTime), totalSafeTime);
 
-            if ((world.getTime() - startTime) > totalSafeTime) {
+            if ((time - startTime) > totalSafeTime) {
                 this.bar.setActive();
                 this.borderShrinkStarted = true;
-                this.shrinkStartTime = world.getTime();
+                this.shrinkStartTime = time;
                 this.space.getPlayers().participants().sendMessage(Text.literal("The worldborder has started shrinking!").formatted(Formatting.RED));
 
                 world.getWorldBorder().interpolateSize(config.borderConfig.startSize, config.borderConfig.endSize, 1000L * config.borderConfig.shrinkSecs);
@@ -180,7 +182,7 @@ public final class SurvivalGamesActive {
         } else {
             long totalShrinkTime = config.borderConfig.shrinkSecs * 20L;
 
-            if ((world.getTime() - shrinkStartTime) > totalShrinkTime || world.getWorldBorder().getSize() == this.config.borderConfig.endSize) {
+            if ((time - shrinkStartTime) > totalShrinkTime || world.getWorldBorder().getSize() == this.config.borderConfig.endSize) {
                 if (!this.finished) {
                     this.space.getPlayers().participants().sendMessage(Text.literal("Last one standing wins!").formatted(Formatting.BLUE));
                     world.getWorldBorder().setDamagePerBlock(2.5);
@@ -190,11 +192,9 @@ public final class SurvivalGamesActive {
                     this.finished = true;
                 }
             } else {
-                this.bar.tickActive(totalShrinkTime - (world.getTime() - shrinkStartTime), totalShrinkTime);
+                this.bar.tickActive(totalShrinkTime - (time - shrinkStartTime), totalShrinkTime);
             }
         }
-
-        long time = this.world.getTime();
 
         if (time > this.gameCloseTick) {
             this.space.close(GameCloseReason.FINISHED);

--- a/src/main/java/supercoder79/survivalgames/game/SurvivalGamesActive.java
+++ b/src/main/java/supercoder79/survivalgames/game/SurvivalGamesActive.java
@@ -267,17 +267,23 @@ public final class SurvivalGamesActive {
         if (survival == 1) {
             for (ServerPlayerEntity participant : this.space.getPlayers().participants()) {
                 if (participant.interactionManager.isSurvivalLike()) {
-                    players.sendMessage(Text.literal(participant.getNameForScoreboard() + " won!").formatted(Formatting.GOLD));
-                    this.gameCloseTick = this.space.getTime() + (20 * 10);
+                    this.endGame(Text.literal(participant.getNameForScoreboard() + " won!").formatted(Formatting.GOLD));
                     break;
                 }
             }
+        } else if (survival == 0) {
+            this.endGame(Text.literal("Nobody won!").formatted(Formatting.GOLD));
         }
     }
 
     private void spawnSpectator(ServerPlayerEntity player, ServerWorld world) {
         this.spawnLogic.resetPlayer(player, GameMode.SPECTATOR);
         this.spawnLogic.spawnPlayerAtCenter(player, world);
+    }
+
+    private void endGame(Text message) {
+        this.space.getPlayers().sendMessage(message);
+        this.gameCloseTick = this.space.getTime() + (20 * 10);
     }
 
     private EventResult onBreakBlock(ServerPlayerEntity player, ServerWorld world, BlockPos pos) {


### PR DESCRIPTION
A delay was added to game closing in 33967b18d4eb761614e08ccb62bc4a0afebfa0ea. This implementation used the world time to determine the tick which the game should close. Later, in #12, the tick was changed to be calculated using the game space time, but was compared against the world time. This pull request restores the correct behavior by changing all time calculations and checks to use the game space time.

This pull request also implements a fix for singleplayer where the game would never end upon the game's sole player being eliminated.